### PR TITLE
Fix bug with CDC data where coordinates are missing

### DIFF
--- a/examples/test_client.py
+++ b/examples/test_client.py
@@ -1,7 +1,6 @@
 """Test client functionality."""
 import asyncio
 import logging
-import os
 
 from aiohttp import ClientSession
 
@@ -10,24 +9,26 @@ from pyoutbreaksnearme.errors import OutbreaksNearMeError
 
 _LOGGER = logging.getLogger()
 
-LATITUDE = os.getenv("LATITUDE")
-LONGITUDE = os.getenv("LONGITUDE")
-
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
     async with ClientSession() as session:
-        logging.basicConfig(level=logging.INFO)
+        logging.basicConfig(level=logging.DEBUG)
 
         client = Client(session=session)
         try:
             nearest_user_data = await client.user_data.async_get_nearest_by_coordinates(
-                LATITUDE, LONGITUDE
+                39.7251035, -104.99918
             )
             _LOGGER.info("Nearest user data: %s", nearest_user_data)
 
             user_totals_data = await client.user_data.async_get_totals()
             _LOGGER.info("User data totals: %s", user_totals_data)
+
+            nearest_cdc_data = await client.cdc_data.async_get_nearest_by_coordinates(
+                39.7251035, -104.99918
+            )
+            _LOGGER.info("Nearest CDC data: %s", nearest_cdc_data)
         except OutbreaksNearMeError as err:
             _LOGGER.error(err)
 

--- a/pyoutbreaksnearme/data/__init__.py
+++ b/pyoutbreaksnearme/data/__init__.py
@@ -27,7 +27,11 @@ class Data:  # pylint: disable=too-few-public-methods
             "get", self._nearest_data_endpoint
         )
         feature = min(
-            raw_user_report_data["features"],
+            (
+                feature
+                for feature in raw_user_report_data["features"]
+                if feature["geometry"]["coordinates"][0] is not None
+            ),
             key=lambda r: haversine(
                 latitude,
                 longitude,

--- a/tests/fixtures/nonuserstats_us_response.json
+++ b/tests/fixtures/nonuserstats_us_response.json
@@ -25,6 +25,28 @@
           34.91131525
         ]
       }
+    },
+    {
+      "id": "99999",
+      "type": "Feature",
+      "properties": {
+        "country": "US",
+        "state": "Grand Princess",
+        "county": null,
+        "confirmed": 103,
+        "death": 3,
+        "iRateConfirm": 0,
+        "iRateDeath": 0,
+        "paintConfirm": "#f0f0f0",
+        "paintDeath": "#f0f0f0"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          null,
+          null
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
**Describe what the PR does:**

The CDC data endpoint can sometimes return reports for locations that don't have coordinates, which causes an unhandled exception.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
