### PR TITLE
Fix issue with incorrect Python version spec

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1583,5 +1583,5 @@ multidict = ">=4.0"
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.10,<=3.12"
-content-hash = "b552eab397cc05c0dcff3e2d0cf17ea22c68eda1589913a1846a114cc0b96b59"
+python-versions = "^3.10"
+content-hash = "58175b5dda4e7b7e65fea1838f8aaccaa444984badf536822662d9e581abd153"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ classifiers = [
 [tool.poetry.dependencies]
 aiohttp = ">=3.9.0b0"
 certifi = ">=2023.07.22"
-python = ">=3.10,<=3.12"
+python = "^3.10"
 ujson = "^5.4.0"
 yarl = ">=1.9.2"
 


### PR DESCRIPTION
**Describe what the PR does:**

The current version spec was too restrictive and disallowed patch versions of 3.12.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
